### PR TITLE
Disable rpicam-apps libav dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ cd rpicam-apps
 Run the following `meson` command to configure the build:
 
 ```bash
-meson setup build -Denable_libav=enabled -Denable_drm=enabled -Denable_egl=enabled -Denable_qt=enabled -Denable_opencv=disabled -Denable_tflite=disabled -Denable_hailo=disabled
+meson setup build -Denable_libav=disabled -Denable_drm=enabled -Denable_egl=enabled -Denable_qt=enabled -Denable_opencv=disabled -Denable_tflite=disabled -Denable_hailo=disabled
 ```
 
 #### Build rpicam-apps


### PR DESCRIPTION
This PR disables LibAV support in the rpicam-apps build. Recent rpicam-apps changes (since v1.10.0) require newer LibAV versions than those available in Raspberry Pi OS, causing build failures when enable_libav is on.

**Reason**

Enabling LibAV currently fails due to outdated system packages, as discussed here:
[https://forums.raspberrypi.com/viewtopic.php?t=392649](https://forums.raspberrypi.com/viewtopic.php?t=392649&utm_source=chatgpt.com)

Disabling it ensures successful build.