### PR TITLE
Add trigger mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,21 +310,26 @@ meson setup build -Denable_libav=enabled -Denable_drm=enabled -Denable_egl=enabl
 ```
 
 > [!IMPORTANT]
-> `-Denable_libav` enables optional video encode/decode support (FFmpeg / `libavcodec`).
-> 
-> - **Debian Bookworm**: the packaged `libav*` version is **too old** to build `rpicam-apps` releases **newer than v1.9.0** with libav enabled.
->   - On Bookworm this typically shows up as build errors like “libavcodec API version is too old”, because Bookworm ships `libavcodec` **59.x** while newer `rpicam-apps` expects **libavcodec >= 60** (see [Raspberry Pi forum thread](https://forums.raspberrypi.com/viewtopic.php?t=392649)).
->   - If you want libav support on Bookworm, check out the `rpicam-apps` **v1.9.0** before running `meson setup`:
-> 
->     ```bash
->     git checkout v1.9.0
->     ```
->   - If you are building **`rpicam-apps` > v1.9.0** on Bookworm, you must disable libav:
->
->     ```bash
->     meson setup build -Denable_libav=disabled -Denable_drm=enabled -Denable_egl=enabled -Denable_qt=enabled -Denable_opencv=disabled -Denable_tflite=disabled -Denable_hailo=disabled
->     ```
-> - **Debian Trixie**: build `rpicam-apps` as usual with `-Denable_libav=enabled` (no need to check out an older version).
+> On Raspberry Pi OS **Bookworm**, the packaged `libav*` is **too old** for `rpicam-apps` newer than v1.9.0.
+
+<details>
+<summary>Bookworm libav workaround</summary>
+
+Bookworm ships `libavcodec` **59.x** while newer `rpicam-apps` expects **libavcodec >= 60**, causing build errors like “libavcodec API version is too old” (see [Raspberry Pi forum thread](https://forums.raspberrypi.com/viewtopic.php?t=392649)).
+
+If you want libav support on Bookworm, check out `rpicam-apps` **v1.9.0** before running `meson setup`:
+
+```bash
+git checkout v1.9.0
+```
+
+If you are building **`rpicam-apps` > v1.9.0** on Bookworm, you must disable libav:
+
+```bash
+meson setup build -Denable_libav=disabled -Denable_drm=enabled -Denable_egl=enabled -Denable_qt=enabled -Denable_opencv=disabled -Denable_tflite=disabled -Denable_hailo=disabled
+```
+
+</details>
 
 #### Build rpicam-apps
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Raspberry Pi kernel driver for the Onsemi AR0234CS — a 2.3MP global shutter 1/
 - 8-bit and 10-bit RAW output
 - 1920×1200 @ 120 fps (full resolution)
 - 960×600 @ 237 fps (2×2 binning)
+- External trigger modes (pulsed, automatic, sync-sink)
 
 ## Prerequisites
 
@@ -186,11 +187,9 @@ Maximum trigger frequency for pulsed mode:
 
 | Resolution | Lanes | Max trigger frequency |
 |---|---|---|
-| **1920×1200 (full resolution)** | | |
-| | 2 | 30 Hz |
+| **1920×1200 (full resolution)** | 2 | 30 Hz |
 | | 4 | 60 Hz |
-| **960×600 (2×2 binned)** | | |
-| | 2 | 60 Hz |
+| **960×600 (2×2 binned)** | 2 | 60 Hz |
 | | 4 | 120 Hz |
 
 #### sync-sink

--- a/README.md
+++ b/README.md
@@ -169,11 +169,11 @@ rpicam-hello -t 0 --qt-preview --shutter 10000 --gain 2.0
 ```
 
 > [!IMPORTANT]
-> The shutter value directly controls the exposure time and must satisfy:
+> Always specify a fixed shutter duration and gain, to ensure the AGC does not try to adjust them automatically. With external trigger the AGC tends to go unstable. In pulsed mode, the shutter value directly controls the sensor's exposure time and must satisfy:
 >
-> `shutter < (1 / trigger_fps) - frame_readout_time`
+> `exposure_time < trigger_period - (1 / max_fps) - ~1.6 ms`
 >
-> Leaving either parameter on auto may cause AGC instability.
+> Where `max_fps` is the maximum framerate for your mode from the [output formats](#output-formats) table, and ~1.6 ms accounts for MIPI wakeup and internal sensor overhead. For example, at full resolution 4-lane 10-bit (max 120 fps) triggered at 30Hz: `1/30 - 1/120 - 1.6 ms ≈ 23.7 ms` maximum exposure time.
 
 #### sync-sink
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ dtoverlay=ar0234,link-frequency=360000000
 | 360MHz | 720 Mbps | 4 | 8 | 1920 | 1200 | 120 fps |
 | 450MHz | 900 Mbps | 4 | 10 | 1920 | 1200 | 120 fps |
 
+> [!NOTE]
+> These framerates do not apply to pulsed trigger mode — see [external-trigger](#external-trigger).
+
 > [!TIP]
 > You can combine options. Example `cam0 + 4 lanes + 360 MHz`:
 > ```ini
@@ -162,7 +165,9 @@ The sensor stays in standby and waits for activity on the `TRIG` pin. Exposure a
 dtoverlay=ar0234,external-trigger
 ```
 
-When using `rpicam-apps` in pulsed mode, start the camera with a fixed shutter duration and gain:
+---
+
+When using `rpicam-apps` with sensor driven in **pulsed** trigger mode, start the camera with a fixed shutter duration and gain:
 
 ```bash
 rpicam-hello -t 0 --qt-preview --shutter 10000 --gain 2.0
@@ -175,7 +180,18 @@ The shutter value directly controls the sensor's exposure time and must satisfy:
 
 `exposure_time < trigger_period - (1 / max_fps) - ~1.6 ms`
 
-Where `max_fps` is the maximum framerate for your mode from the [output formats](#output-formats) table, and ~1.6 ms accounts for MIPI wakeup and internal sensor overhead. For example, at full resolution 4-lane 10-bit (max 120 fps) triggered at 30Hz: `1/30 - 1/120 - 1.6 ms ≈ 23.7 ms` maximum exposure time.
+Where `max_fps` is the maximum framerate for your mode from the [output formats](#output-formats) table, and ~1.6 ms accounts for MIPI wakeup and internal sensor overhead. For example, at full resolution 4-lane 10-bit (max 120 fps) triggered at 30 Hz: `1/30 - 1/120 - 1.6 ms ≈ 23.7 ms` maximum exposure time.
+
+Maximum trigger frequency for pulsed mode:
+
+| Resolution | Lanes | Max trigger frequency |
+|---|---|---|
+| **1920×1200 (full resolution)** | | |
+| | 2 | 30 Hz |
+| | 4 | 60 Hz |
+| **960×600 (2×2 binned)** | | |
+| | 2 | 60 Hz |
+| | 4 | 120 Hz |
 
 #### sync-sink
 

--- a/README.md
+++ b/README.md
@@ -149,25 +149,43 @@ dtoverlay=ar0234,link-frequency=360000000
 
 ### Trigger modes
 
-The AR0234 supports two external trigger modes. Both use the `TRIG` pin on the camera module as the external signal input.
+AR0234 supports two external trigger modes. Both use `TRIG` pin on the camera module as the external signal input. The trigger pulse only initiates the capture — the exposure time remains controlled by the sensor's integration time register.
 
 #### external-trigger
 
-The sensor stays in standby and captures a single frame each time a pulse is received on the `TRIG` pin. Exposure and readout happen sequentially — the sensor does not begin readout until exposure is complete. If the `TRIG` signal stays high, the sensor outputs frames continuously at the configured framerate (automatic mode). The framerate is otherwise determined by the trigger pulse frequency.
+The sensor stays in standby and waits for activity on the `TRIG` pin. Exposure and readout happen sequentially — the sensor does not begin readout until exposure is complete. Two sub-modes are available:
+
+- **Pulsed** — each pulse on the `TRIG` pin captures a single frame (minimum pulse width ~1 µs). The framerate is determined by the pulse frequency.
+- **Automatic** — if the `TRIG` signal stays high, the sensor outputs frames continuously at the configured framerate.
 
 ```ini
 dtoverlay=ar0234,external-trigger
 ```
 
+When using `rpicam-apps`, start the camera with a fixed shutter duration and gain:
+
+```bash
+rpicam-hello -t 0 --qt-preview --shutter 10000 --gain 2.0
+```
+
+> [!IMPORTANT]
+> The shutter value directly controls the exposure time and must satisfy:
+>
+> `shutter < (1 / trigger_fps) - frame_readout_time`
+>
+> Leaving either parameter on auto may cause AGC instability.
+
 #### sync-sink
 
-In this mode the sensor streams continuously but locks its frame timing to the external `TRIG` signal. Unlike `external-trigger`, exposure and readout overlap (pipelined), so higher framerates are possible. The trigger period must not be shorter than the configured frame length.
+The sensor streams continuously but locks its frame timing to the external `TRIG` signal. Unlike `external-trigger`, exposure and readout overlap (pipelined), so higher framerates are possible. The trigger period must not be shorter than the configured frame length.
 
 ```ini
 dtoverlay=ar0234,sync-sink
 ```
 
-Trigger modes can also be set at runtime via the module parameter without rebooting:
+---
+
+Trigger modes can also be set at runtime via the module parameter:
 
 ```bash
 # 0=off, 1=external-trigger, 2=sync-sink
@@ -175,7 +193,7 @@ echo 1 | sudo tee /sys/module/ar0234/parameters/trigger_mode
 ```
 
 > [!NOTE]
-> The device tree overlay setting takes precedence over the module parameter. If `external-trigger` or `sync-sink` is set in the overlay, the module parameter is ignored.
+> The module parameter is global — in a multi-camera setup it applies to all AR0234 sensors. To configure each sensor independently, use the device tree overlay options instead. The device tree setting takes precedence over the module parameter.
 
 ### always-on
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ dtoverlay=ar0234,link-frequency=360000000
 
 ### Trigger modes
 
-AR0234 supports two external trigger modes. Both use `TRIG` pin on the camera module as the external signal input. The trigger pulse only initiates the capture — the exposure time remains controlled by the sensor's integration time register.
+AR0234 supports two external trigger modes. Both use the `TRIG` pin on the camera module as the external signal input. The `TRIG` pin is a **1.8V logic level** input wired directly to the sensor. The trigger pulse only initiates the capture — the exposure time remains controlled by the sensor's integration time register.
 
 #### external-trigger
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ The `ar0234` overlay supports comma-separated options to override defaults:
 | `cam0` | Use cam0 port instead of cam1 | cam1 |
 | `4lane` | Use 4-lane MIPI CSI-2 (if wired) | 2 lanes |
 | `link-frequency=<Hz>` | Set MIPI CSI-2 link frequency (Hz) | 450000000 |
+| `external-trigger` | Pulse/automatic trigger mode via TRIG pin | off |
+| `sync-sink` | Multi-sensor sync mode (frame timing locked to TRIG pin) | off |
+| `always-on` | Keep regulator powered (prevents runtime PM power-off) | off |
 
 ### cam0
 
@@ -113,7 +116,7 @@ To set the link frequency to 360 MHz, append `,link-frequency=360000000`:
 dtoverlay=ar0234,link-frequency=360000000
 ```
 
-### Sensor output formats
+#### Output formats
 
 | Link frequency | Data rate / lane | Lanes | Bit depth | Width | Height | Max FPS |
 |---|---|---|---|---|---|---|
@@ -143,6 +146,44 @@ dtoverlay=ar0234,link-frequency=360000000
 > ```ini
 > dtoverlay=ar0234,cam0,4lane,link-frequency=360000000
 > ```
+
+### Trigger modes
+
+The AR0234 supports two external trigger modes. Both use the `TRIG` pin on the camera module as the external signal input.
+
+#### external-trigger
+
+The sensor stays in standby and captures a single frame each time a pulse is received on the `TRIG` pin. Exposure and readout happen sequentially — the sensor does not begin readout until exposure is complete. If the `TRIG` signal stays high, the sensor outputs frames continuously at the configured framerate (automatic mode). The framerate is otherwise determined by the trigger pulse frequency.
+
+```ini
+dtoverlay=ar0234,external-trigger
+```
+
+#### sync-sink
+
+In this mode the sensor streams continuously but locks its frame timing to the external `TRIG` signal. Unlike `external-trigger`, exposure and readout overlap (pipelined), so higher framerates are possible. The trigger period must not be shorter than the configured frame length.
+
+```ini
+dtoverlay=ar0234,sync-sink
+```
+
+Trigger modes can also be set at runtime via the module parameter without rebooting:
+
+```bash
+# 0=off, 1=external-trigger, 2=sync-sink
+echo 1 > /sys/module/ar0234/parameters/trigger_mode
+```
+
+> [!NOTE]
+> The device tree overlay setting takes precedence over the module parameter. If `external-trigger` or `sync-sink` is set in the overlay, the module parameter is ignored.
+
+### always-on
+
+The `always-on` option keeps the camera regulator permanently enabled, preventing the kernel from powering off the sensor during runtime power management suspend.
+
+```ini
+dtoverlay=ar0234,always-on
+```
 
 ## libcamera
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ dtoverlay=ar0234,link-frequency=360000000
 
 ### Trigger modes
 
-AR0234 supports two external trigger modes. Both use the `TRIG` pin on the camera module as the external signal input. The `TRIG` pin is a **1.8V logic level** input wired directly to the sensor. The trigger pulse only initiates the capture — the exposure time remains controlled by the sensor's integration time register.
+AR0234 supports two external trigger modes. Both use `TRIG` pin on the camera module as the external signal input. `TRIG` pin is a **1.8V logic level** input wired directly to the sensor. The trigger pulse only initiates the capture — the exposure time remains controlled by the sensor's integration time register.
 
 #### external-trigger
 

--- a/README.md
+++ b/README.md
@@ -162,18 +162,20 @@ The sensor stays in standby and waits for activity on the `TRIG` pin. Exposure a
 dtoverlay=ar0234,external-trigger
 ```
 
-When using `rpicam-apps`, start the camera with a fixed shutter duration and gain:
+When using `rpicam-apps` in pulsed mode, start the camera with a fixed shutter duration and gain:
 
 ```bash
 rpicam-hello -t 0 --qt-preview --shutter 10000 --gain 2.0
 ```
 
 > [!IMPORTANT]
-> Always specify a fixed shutter duration and gain, to ensure the AGC does not try to adjust them automatically. With external trigger the AGC tends to go unstable. In pulsed mode, the shutter value directly controls the sensor's exposure time and must satisfy:
->
-> `exposure_time < trigger_period - (1 / max_fps) - ~1.6 ms`
->
-> Where `max_fps` is the maximum framerate for your mode from the [output formats](#output-formats) table, and ~1.6 ms accounts for MIPI wakeup and internal sensor overhead. For example, at full resolution 4-lane 10-bit (max 120 fps) triggered at 30Hz: `1/30 - 1/120 - 1.6 ms ≈ 23.7 ms` maximum exposure time.
+> Always specify a fixed shutter duration and gain, to ensure the AGC does not try to adjust them automatically. With external trigger the AGC tends to go unstable.
+
+The shutter value directly controls the sensor's exposure time and must satisfy:
+
+`exposure_time < trigger_period - (1 / max_fps) - ~1.6 ms`
+
+Where `max_fps` is the maximum framerate for your mode from the [output formats](#output-formats) table, and ~1.6 ms accounts for MIPI wakeup and internal sensor overhead. For example, at full resolution 4-lane 10-bit (max 120 fps) triggered at 30Hz: `1/30 - 1/120 - 1.6 ms ≈ 23.7 ms` maximum exposure time.
 
 #### sync-sink
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ AR0234 supports two external trigger modes. Both use `TRIG` pin on the camera mo
 
 The sensor stays in standby and waits for activity on the `TRIG` pin. Exposure and readout happen sequentially — the sensor does not begin readout until exposure is complete. Two sub-modes are available:
 
-- **Pulsed** — each pulse on the `TRIG` pin captures a single frame (minimum pulse width ~1 µs). The framerate is determined by the pulse frequency.
+- **Pulsed** — each pulse on the `TRIG` pin captures a single frame (minimum pulse width at least 125 ns — 3 EXTCLK cycles at 24 MHz). The framerate is determined by the pulse frequency.
 - **Automatic** — if the `TRIG` signal stays high, the sensor outputs frames continuously at the configured framerate.
 
 ```ini

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Trigger modes can also be set at runtime via the module parameter without reboot
 
 ```bash
 # 0=off, 1=external-trigger, 2=sync-sink
-echo 1 > /sys/module/ar0234/parameters/trigger_mode
+echo 1 | sudo tee /sys/module/ar0234/parameters/trigger_mode
 ```
 
 > [!NOTE]

--- a/ar0234-overlay.dts
+++ b/ar0234-overlay.dts
@@ -56,6 +56,13 @@
 		};
 	};
 
+	reg_alwayson_frag: fragment@7 {
+		target = <&cam1_reg>;
+		__dormant__ {
+			regulator-always-on;
+		};
+	};
+
 	i2c_frag: fragment@100 {
 		target = <&i2c_csi_dsi>;
 		__overlay__ {
@@ -135,9 +142,11 @@
 		cam0 = <&i2c_frag>, "target:0=",<&i2c_csi_dsi0>,
 			   <&csi_frag>, "target:0=",<&csi0>,
 			   <&clk_frag>, "target:0=",<&cam0_clk>,
+			   <&reg_alwayson_frag>, "target:0=",<&cam0_reg>,
 			   <&cam_node>, "clocks:0=",<&cam0_clk>,
 			   <&cam_node>, "vana-supply:0=",<&cam0_reg>;
 		link-frequency = <&cam_endpoint>,"link-frequencies#0";
+		always-on = <0>, "+7";
 		external-trigger = <0>, "+103";
 		sync-sink = <0>, "+104";
 	};

--- a/ar0234-overlay.dts
+++ b/ar0234-overlay.dts
@@ -113,6 +113,20 @@
 		};
 	};
 
+	fragment@103 {
+		target = <&cam_node>;
+		__dormant__ {
+			trigger-mode = <1>;
+		};
+	};
+
+	fragment@104 {
+		target = <&cam_node>;
+		__dormant__ {
+			trigger-mode = <2>;
+		};
+	};
+
 	__overrides__ {
 		4lane = <0>, "-3+4-5+6";
 		rotation = <&cam_node>,"rotation:0";
@@ -124,6 +138,8 @@
 			   <&cam_node>, "clocks:0=",<&cam0_clk>,
 			   <&cam_node>, "vana-supply:0=",<&cam0_reg>;
 		link-frequency = <&cam_endpoint>,"link-frequencies#0";
+		external-trigger = <0>, "+103";
+		sync-sink = <0>, "+104";
 	};
 };
 

--- a/ar0234.c
+++ b/ar0234.c
@@ -25,7 +25,7 @@
 
 static int trigger_mode;
 module_param(trigger_mode, int, 0644);
-MODULE_PARM_DESC(trigger_mode, "Set trigger mode: 0=off, 1=on, 2=slave-sync");
+MODULE_PARM_DESC(trigger_mode, "Set trigger mode: 0=off, 1=external-trigger, 2=sync-sink");
 
 /* Registers */
 #define AR0234_REG_CHIP_ID CCI_REG16(0x3000)
@@ -140,6 +140,7 @@ MODULE_PARM_DESC(trigger_mode, "Set trigger mode: 0=off, 1=on, 2=slave-sync");
 #define AR0234_TEST_PATTERN_WALKING_1S 256
 
 /* Trigger modes */
+#define AR0234_TRIGGER_MODE_OFF 0
 #define AR0234_TRIGGER_MODE_SLAVE_SYNC 2
 
 /* Native and active pixel array sizes */
@@ -997,7 +998,7 @@ static int ar0234_stream_on(struct ar0234 *ar0234)
 		     ar0234->hw_config.trigger_mode :
 		     trigger_mode;
 
-	if (tm == 0) {
+	if (tm == AR0234_TRIGGER_MODE_OFF) {
 		ret = ar0234_mode_select(ar0234, true);
 	} else {
 		u16 reset_val = AR0234_RESET_DEFAULT | AR0234_RESET_GPI_EN |

--- a/ar0234.c
+++ b/ar0234.c
@@ -23,6 +23,10 @@
 #include <media/v4l2-fwnode.h>
 #include <media/v4l2-subdev.h>
 
+static int trigger_mode;
+module_param(trigger_mode, int, 0644);
+MODULE_PARM_DESC(trigger_mode, "Set trigger mode: 0=off, 1=on");
+
 /* Registers */
 #define AR0234_REG_CHIP_ID CCI_REG16(0x3000)
 #define AR0234_REG_Y_ADDR_START CCI_REG16(0x3002)

--- a/ar0234.c
+++ b/ar0234.c
@@ -63,6 +63,7 @@ MODULE_PARM_DESC(trigger_mode, "Set trigger mode: 0=off, 1=on");
 #define AR0234_REG_DIGITAL_TEST CCI_REG16(0x30B0)
 #define AR0234_REG_TEMPSENS_CTRL CCI_REG16(0x30B4)
 #define AR0234_REG_MFR_30BA CCI_REG16(0x30BA)
+#define AR0234_REG_GRR_CONTROL1 CCI_REG16(0x30CE)
 #define AR0234_REG_AE_LUMA_TARGET CCI_REG16(0x3102)
 #define AR0234_REG_DELTA_DK_CONTROL CCI_REG16(0x3180)
 #define AR0234_REG_DATA_FORMAT_BITS CCI_REG16(0x31AC)
@@ -94,6 +95,15 @@ MODULE_PARM_DESC(trigger_mode, "Set trigger mode: 0=off, 1=on");
 #define AR0234_FLL_MAX (0xFFFF + AR0234_FLL_OVERHEAD)
 #define AR0234_VBLANK_MIN (16 + AR0234_FLL_OVERHEAD)
 #define AR0234_LINE_LENGTH_PCK_DEF 612
+
+/* AR0234_REG_RESET Bits */
+#define AR0234_RESET_DEFAULT 0x2058
+#define AR0234_RESET_STREAM BIT(2)
+#define AR0234_RESET_GPI_EN BIT(8)
+#define AR0234_RESET_FORCED_PLL_ON BIT(11)
+
+/* AR0234_REG_GRR_CONTROL1 Bits */
+#define AR0234_GRR_SLAVE_SH_SYNC BIT(8)
 
 /* Exposure control */
 #define AR0234_EXPOSURE_MIN 2
@@ -930,7 +940,8 @@ static int ar0234_soft_reset(struct ar0234 *ar0234)
 	/* 200ms */
 	usleep_range(200000, 201000);
 
-	return cci_write(ar0234->regmap, AR0234_REG_RESET, 0x2058, &ret);
+	return cci_write(ar0234->regmap, AR0234_REG_RESET, AR0234_RESET_DEFAULT,
+			 &ret);
 }
 
 static inline int

--- a/ar0234.c
+++ b/ar0234.c
@@ -988,6 +988,33 @@ static inline int ar0234_mode_select(struct ar0234 *ar0234, bool stream_on)
 			 NULL);
 }
 
+static int ar0234_stream_on(struct ar0234 *ar0234)
+{
+	int ret = 0;
+	int tm;
+
+	tm = (ar0234->hw_config.trigger_mode >= 0) ?
+		     ar0234->hw_config.trigger_mode :
+		     trigger_mode;
+
+	if (tm == 0) {
+		ret = ar0234_mode_select(ar0234, true);
+	} else {
+		u16 reset_val = AR0234_RESET_DEFAULT | AR0234_RESET_GPI_EN |
+				AR0234_RESET_FORCED_PLL_ON;
+
+		if (tm == AR0234_TRIGGER_MODE_SLAVE_SYNC) {
+			reset_val |= AR0234_RESET_STREAM;
+			ret = cci_write(ar0234->regmap, AR0234_REG_GRR_CONTROL1,
+					AR0234_GRR_SLAVE_SH_SYNC, NULL);
+		}
+
+		cci_write(ar0234->regmap, AR0234_REG_RESET, reset_val, &ret);
+	}
+
+	return ret;
+}
+
 static int ar0234_start_streaming(struct ar0234 *ar0234)
 {
 	struct i2c_client *client = v4l2_get_subdevdata(&ar0234->sd);
@@ -1053,8 +1080,8 @@ static int ar0234_start_streaming(struct ar0234 *ar0234)
 	if (ret)
 		return ret;
 
-	/* set stream on register */
-	ret = ar0234_mode_select(ar0234, true);
+	ret = ar0234_stream_on(ar0234);
+
 	return ret;
 }
 
@@ -1063,10 +1090,11 @@ static void ar0234_stop_streaming(struct ar0234 *ar0234)
 	struct i2c_client *client = v4l2_get_subdevdata(&ar0234->sd);
 	int ret;
 
-	/* set stream off */
-	ret = ar0234_mode_select(ar0234, false);
+	ret = cci_write(ar0234->regmap, AR0234_REG_RESET, AR0234_RESET_DEFAULT,
+			NULL);
 	if (ret < 0)
-		dev_err(&client->dev, "%s failed to set stream\n", __func__);
+		dev_err(&client->dev, "%s failed to stop streaming\n",
+			__func__);
 
 	pm_runtime_mark_last_busy(&client->dev);
 	pm_runtime_put_autosuspend(&client->dev);

--- a/ar0234.c
+++ b/ar0234.c
@@ -25,7 +25,8 @@
 
 static int trigger_mode;
 module_param(trigger_mode, int, 0644);
-MODULE_PARM_DESC(trigger_mode, "Set trigger mode: 0=off, 1=external-trigger, 2=sync-sink");
+MODULE_PARM_DESC(trigger_mode,
+		 "Set trigger mode: 0=off, 1=external-trigger, 2=sync-sink");
 
 /* Registers */
 #define AR0234_REG_CHIP_ID CCI_REG16(0x3000)
@@ -1452,10 +1453,11 @@ static int ar0234_parse_hw_config(struct ar0234 *ar0234,
 	ret = of_property_read_u32(client->dev.of_node, "trigger-mode", &tm);
 	ar0234->hw_config.trigger_mode = (ret == 0) ? tm : -1;
 
-	dev_info(ar0234->dev,
-		 "extclk: %luHz, link_frequency: %lluHz, lanes: %d\n",
-		 extclk_frequency, ep_cfg.link_frequencies[0],
-		 hw_config->num_data_lanes);
+	dev_info(
+		ar0234->dev,
+		"extclk: %luHz, link_frequency: %lluHz, lanes: %d, trigger_mode: %d\n",
+		extclk_frequency, ep_cfg.link_frequencies[0],
+		hw_config->num_data_lanes, hw_config->trigger_mode);
 
 	ret = 0;
 

--- a/ar0234.c
+++ b/ar0234.c
@@ -25,7 +25,7 @@
 
 static int trigger_mode;
 module_param(trigger_mode, int, 0644);
-MODULE_PARM_DESC(trigger_mode, "Set trigger mode: 0=off, 1=on");
+MODULE_PARM_DESC(trigger_mode, "Set trigger mode: 0=off, 1=on, 2=slave-sync");
 
 /* Registers */
 #define AR0234_REG_CHIP_ID CCI_REG16(0x3000)
@@ -138,6 +138,9 @@ MODULE_PARM_DESC(trigger_mode, "Set trigger mode: 0=off, 1=on");
 #define AR0234_TEST_PATTERN_FADE_TO_GREY 3
 #define AR0234_TEST_PATTERN_PN9 4
 #define AR0234_TEST_PATTERN_WALKING_1S 256
+
+/* Trigger modes */
+#define AR0234_TRIGGER_MODE_SLAVE_SYNC 2
 
 /* Native and active pixel array sizes */
 #define AR0234_NATIVE_WIDTH 1940U
@@ -440,6 +443,7 @@ struct ar0234_hw_config {
 	struct gpio_desc *gpio_reset;
 	unsigned int num_data_lanes;
 	enum ar0234_lane_mode_id lane_mode;
+	int trigger_mode;
 };
 
 struct ar0234 {
@@ -1324,7 +1328,8 @@ static void ar0234_free_controls(struct ar0234 *ar0234)
 	mutex_destroy(&ar0234->mutex);
 }
 
-static int ar0234_parse_hw_config(struct ar0234 *ar0234)
+static int ar0234_parse_hw_config(struct ar0234 *ar0234,
+				  struct i2c_client *client)
 {
 	struct v4l2_fwnode_endpoint ep_cfg = {
 		.bus_type = V4L2_MBUS_CSI2_DPHY,
@@ -1333,7 +1338,7 @@ static int ar0234_parse_hw_config(struct ar0234 *ar0234)
 	struct ar0234_hw_config *hw_config = &ar0234->hw_config;
 	unsigned long extclk_frequency;
 	int ret = -EINVAL;
-	unsigned int i;
+	unsigned int i, tm;
 
 	for (i = 0; i < AR0234_SUPPLY_AMOUNT; i++)
 		hw_config->supplies[i].supply = ar0234_supply_names[i];
@@ -1415,6 +1420,9 @@ static int ar0234_parse_hw_config(struct ar0234 *ar0234)
 
 	ar0234->pll_config = &ar0234_pll_configs[i];
 
+	ret = of_property_read_u32(client->dev.of_node, "trigger-mode", &tm);
+	ar0234->hw_config.trigger_mode = (ret == 0) ? tm : -1;
+
 	dev_info(ar0234->dev,
 		 "extclk: %luHz, link_frequency: %lluHz, lanes: %d\n",
 		 extclk_frequency, ep_cfg.link_frequencies[0],
@@ -1442,7 +1450,7 @@ static int ar0234_probe(struct i2c_client *client)
 	v4l2_i2c_subdev_init(&ar0234->sd, client, &ar0234_subdev_ops);
 
 	/* Check the hardware configuration in device tree */
-	ret = ar0234_parse_hw_config(ar0234);
+	ret = ar0234_parse_hw_config(ar0234, client);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
## Summary

- Implement two trigger modes: `external-trigger` (pulse/automatic trigger via TRIG pin) and `sync-sink` (multi-sensor sync with frame timing locked to TRIG pin)
- Add device tree overlay overrides (`external-trigger`, `sync-sink`) and `trigger-mode` module property with per-device DT override taking precedence over the module parameter
- Add `always-on` device tree override

## Details

The AR0234 supports two distinct trigger modes controlled by the TRIG pin:

1. **external-trigger** (mode 1): Sensor stays in standby, captures one frame per trigger pulse. Exposure and readout are sequential. If TRIG stays high, frames are output at the configured framerate (automatic mode).
2. **sync-sink** (mode 2): Sensor streams in master mode but locks frame timing to the external trigger signal.

Trigger mode can be set via:
- Device tree overlay: `dtoverlay=ar0234,external-trigger` or `dtoverlay=ar0234,sync-sink`
- Module parameter: `echo 1 | sudo tee /sys/module/ar0234/parameters/trigger_mode`

An `always-on` overlay option is also added that keeps the regulator powered during runtime PM suspend.

## Test plan

- [x] Normal streaming (mode 0) unaffected by changes
- [x] External trigger: pulsed and automatic sub-modes at various frequencies
- [x] Sync-sink mode with continuous trigger signal
- [x] DT overlay overrides (`external-trigger`, `sync-sink`, `always-on`)
- [x] Module parameter runtime switching
- [x] DT setting takes precedence over module parameter