### PR TITLE
Fix max exposure limit to take into account FLL overhead

### DIFF
--- a/ar0234.c
+++ b/ar0234.c
@@ -536,8 +536,8 @@ static int ar0234_open(struct v4l2_subdev *sd, struct v4l2_subdev_fh *fh)
 
 static void ar0234_adjust_exposure_range(struct ar0234 *ar0234)
 {
-	int exposure_max =
-		ar0234->mode.format->height + ar0234->vblank->val - 1;
+	int exposure_max = ar0234->mode.format->height + ar0234->vblank->val -
+			   AR0234_FLL_OVERHEAD - 1;
 
 	__v4l2_ctrl_modify_range(ar0234->exposure, ar0234->exposure->minimum,
 				 exposure_max, ar0234->exposure->step,


### PR DESCRIPTION
The recent framerate calculation rework introduced a regression in #12.

The VBLANK range was updated to account for the sensor’s internal FLL overhead. However, the exposure range also depends on the FLL register value and was not updated accordingly. As a result, the exposure limits did not properly reflect the adjusted FLL configuration.

## Fix

Recalculate the maximum exposure based on the actual FLL register value, mostly as before, but subtract the FLL overhead as well. This ensures compliance with the sensor limits across the full exposure range and prevents unstable framerates at high exposure values.