### PR TITLE
Add configurable FLASH output pin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ The `ar0234` overlay supports comma-separated options to override defaults:
 | `sync-sink` | Multi-sensor sync mode (frame timing locked to TRIG pin) | off |
 | `always-on` | Keep regulator powered (prevents runtime PM power-off) | off |
 | `flash` | Enable FLASH output pin (HIGH during exposure) | off |
-| `flash-delay=<n>` | Flash lead/lag delay (~3.4 µs/unit 4-lane, ~6.8 µs/unit 2-lane): negative = lead, positive = lag | 0 |
+| `flash-lead=<n>` | Flash lead delay (~3.4 µs/unit 4-lane, ~6.8 µs/unit 2-lane) | 0 |
+| `flash-lag=<n>` | Flash lag delay (~3.4 µs/unit 4-lane, ~6.8 µs/unit 2-lane) | 0 |
 
 ### cam0
 
@@ -233,22 +234,22 @@ To enable the flash output:
 dtoverlay=ar0234,flash
 ```
 
-By default, flash pulse closely follows the exposure period (longer by ~8 µs on 4-lane or ~16 µs on 2-lane due to sensor overhead). The `flash-delay` option shifts flash signal start relative to exposure:
+By default, flash pulse closely follows the exposure period (longer by ~8 µs on 4-lane or ~16 µs on 2-lane due to sensor overhead). The flash signal start can be shifted relative to exposure using `flash-lead` or `flash-lag`:
 
-- **Negative** value — flash starts *before* exposure (lead)
-- **Positive** value — flash starts *after* exposure begins (lag)
+- **`flash-lead`** — flash starts *before* exposure, extending total flash time
+- **`flash-lag`** — flash starts *after* exposure begins, shortening total flash time
 
-The delay value is a signed 8-bit integer (**-128 to +127**), where each unit is approximately **3.4 µs** (4-lane) or **6.8 µs** (2-lane).
+Both accept values in the range 0 to 127, where each unit is approximately **3.4 µs** (4-lane) or **6.8 µs** (2-lane).
 
 ```ini
 # Flash starts ~34 µs before exposure (4-lane)
-dtoverlay=ar0234,4lane,flash,flash-delay=-10
+dtoverlay=ar0234,4lane,flash,flash-lead=10
 
 # Flash starts ~34 µs after exposure begins (4-lane)
-dtoverlay=ar0234,4lane,flash,flash-delay=10
+dtoverlay=ar0234,4lane,flash,flash-lag=10
 ```
 
-Keep the delay small relative to your shutter time. For short exposures (below ~450 µs on 4-lane or ~900 µs on 2-lane), lead (negative) values should not be used and max lag (positive) value is `2 × (shutter_µs / row_µs) - 5`, where row time is ~6.8 µs (4-lane) or ~13.6 µs (2-lane).
+For most use cases, small delay values (single digits) are sufficient. Large delay values combined with short exposure times are not recommended. For short exposures (below ~450 µs on 4-lane or ~900 µs on 2-lane), `flash-lead` should not be used.
 
 > [!NOTE]
 > In trigger mode, flash output is suppressed when the trigger pulse is shorter than ~1.5 ms.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Raspberry Pi kernel driver for the Onsemi AR0234CS — a 2.3MP global shutter 1/
 - 1920×1200 @ 120 fps (full resolution)
 - 960×600 @ 237 fps (2×2 binning)
 - External trigger modes (pulsed, automatic, sync-sink)
+- Flash output with programmable lead/lag delay
 
 ## Prerequisites
 
@@ -87,6 +88,8 @@ The `ar0234` overlay supports comma-separated options to override defaults:
 | `external-trigger` | Pulse/automatic trigger mode via TRIG pin | off |
 | `sync-sink` | Multi-sensor sync mode (frame timing locked to TRIG pin) | off |
 | `always-on` | Keep regulator powered (prevents runtime PM power-off) | off |
+| `flash` | Enable FLASH output pin (HIGH during exposure) | off |
+| `flash-delay=<n>` | Flash lead/lag delay (~3.4 µs/unit 4-lane, ~6.8 µs/unit 2-lane): negative = lead, positive = lag | 0 |
 
 ### cam0
 
@@ -219,6 +222,36 @@ The `always-on` option keeps the camera regulator permanently enabled, preventin
 ```ini
 dtoverlay=ar0234,always-on
 ```
+
+### Flash output
+
+AR0234 has a `FLASH` output pin that goes HIGH during sensor exposure. This can be used to synchronize external illumination such as strobes or LEDs. The pin operates at 1.8V logic level.
+
+To enable the flash output:
+
+```ini
+dtoverlay=ar0234,flash
+```
+
+By default, flash pulse closely follows the exposure period (longer by ~8 µs on 4-lane or ~16 µs on 2-lane due to sensor overhead). The `flash-delay` option shifts flash signal start relative to exposure:
+
+- **Negative** value — flash starts *before* exposure (lead)
+- **Positive** value — flash starts *after* exposure begins (lag)
+
+The delay value is a signed 8-bit integer (**-128 to +127**), where each unit is approximately **3.4 µs** (4-lane) or **6.8 µs** (2-lane).
+
+```ini
+# Flash starts ~34 µs before exposure (4-lane)
+dtoverlay=ar0234,4lane,flash,flash-delay=-10
+
+# Flash starts ~34 µs after exposure begins (4-lane)
+dtoverlay=ar0234,4lane,flash,flash-delay=10
+```
+
+Keep the delay small relative to your shutter time. For short exposures (below ~450 µs on 4-lane or ~900 µs on 2-lane), lead (negative) values should not be used and max lag (positive) value is `2 × (shutter_µs / row_µs) - 5`, where row time is ~6.8 µs (4-lane) or ~13.6 µs (2-lane).
+
+> [!NOTE]
+> In trigger mode, flash output is suppressed when the trigger pulse is shorter than ~1.5 ms.
 
 ## libcamera
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ AR0234 supports two external trigger modes. Both use `TRIG` pin on the camera mo
 
 The sensor stays in standby and waits for activity on the `TRIG` pin. Exposure and readout happen sequentially — the sensor does not begin readout until exposure is complete. Two sub-modes are available:
 
-- **Pulsed** — each pulse on the `TRIG` pin captures a single frame (minimum pulse width at least 125 ns — 3 EXTCLK cycles at 24 MHz). The framerate is determined by the pulse frequency.
+- **Pulsed** — each high pulse on the `TRIG` pin captures a single frame (minimum pulse width at least 125 ns — 3 EXTCLK cycles at 24 MHz). The framerate is determined by the pulse frequency.
 - **Automatic** — if the `TRIG` signal stays high, the sensor outputs frames continuously at the configured framerate.
 
 ```ini

--- a/ar0234-overlay.dts
+++ b/ar0234-overlay.dts
@@ -149,6 +149,8 @@
 		always-on = <0>, "+7";
 		external-trigger = <0>, "+103";
 		sync-sink = <0>, "+104";
+		flash = <&cam_node>,"flash?";
+		flash-delay = <&cam_node>,"flash-delay:0";
 	};
 };
 

--- a/ar0234-overlay.dts
+++ b/ar0234-overlay.dts
@@ -150,7 +150,8 @@
 		external-trigger = <0>, "+103";
 		sync-sink = <0>, "+104";
 		flash = <&cam_node>,"flash?";
-		flash-delay = <&cam_node>,"flash-delay:0";
+		flash-lead = <&cam_node>,"flash-lead:0";
+		flash-lag = <&cam_node>,"flash-lag:0";
 	};
 };
 

--- a/ar0234.c
+++ b/ar0234.c
@@ -109,7 +109,6 @@ MODULE_PARM_DESC(trigger_mode,
 
 /* AR0234_REG_LED_FLASH_CONTROL Bits */
 #define AR0234_FLASH_ENABLE BIT(8)
-#define AR0234_FLASH_LEAD BIT(7)
 
 /* Exposure control */
 #define AR0234_EXPOSURE_MIN 2
@@ -1086,13 +1085,8 @@ static int ar0234_start_streaming(struct ar0234 *ar0234)
 
 	/* Configure flash output if enabled */
 	if (ar0234->hw_config.flash_enable) {
-		u16 flash_val = AR0234_FLASH_ENABLE;
-		s8 delay = ar0234->hw_config.flash_delay;
-
-		if (delay > 0)
-			flash_val |= (delay & 0x7F) | AR0234_FLASH_LEAD;
-		else if (delay < 0)
-			flash_val |= (-delay) & 0x7F;
+		u16 flash_val = AR0234_FLASH_ENABLE |
+				(u8)ar0234->hw_config.flash_delay;
 
 		ret = cci_write(ar0234->regmap, AR0234_REG_LED_FLASH_CONTROL,
 				flash_val, NULL);
@@ -1497,7 +1491,7 @@ static int ar0234_parse_hw_config(struct ar0234 *ar0234,
 		hw_config->num_data_lanes, hw_config->trigger_mode,
 		hw_config->flash_enable ? "enabled" : "disabled",
 		(hw_config->flash_enable && hw_config->flash_delay) ?
-			((hw_config->flash_delay > 0) ? " (lead)" : " (lag)") :
+			((hw_config->flash_delay < 0) ? " (lead)" : " (lag)") :
 			"");
 
 	ret = 0;

--- a/ar0234.c
+++ b/ar0234.c
@@ -1084,6 +1084,25 @@ static int ar0234_start_streaming(struct ar0234 *ar0234)
 		return ret;
 	}
 
+	/* Configure flash output if enabled */
+	if (ar0234->hw_config.flash_enable) {
+		u16 flash_val = AR0234_FLASH_ENABLE;
+		s8 delay = ar0234->hw_config.flash_delay;
+
+		if (delay > 0)
+			flash_val |= (delay & 0x7F) | AR0234_FLASH_LEAD;
+		else if (delay < 0)
+			flash_val |= (-delay) & 0x7F;
+
+		ret = cci_write(ar0234->regmap, AR0234_REG_LED_FLASH_CONTROL,
+				flash_val, NULL);
+		if (ret < 0) {
+			dev_err(&client->dev, "%s failed to configure flash\n",
+				__func__);
+			return ret;
+		}
+	}
+
 	/* Apply customized values from user */
 	ret = __v4l2_ctrl_handler_setup(ar0234->sd.ctrl_handler);
 	if (ret)

--- a/ar0234.c
+++ b/ar0234.c
@@ -78,6 +78,7 @@ MODULE_PARM_DESC(trigger_mode,
 #define AR0234_REG_MIPI_TIMING_4 CCI_REG16(0x31BC)
 #define AR0234_REG_COMPANDING CCI_REG16(0x31D0)
 #define AR0234_REG_PIX_DEF_ID CCI_REG16(0x31E0)
+#define AR0234_REG_LED_FLASH_CONTROL CCI_REG16(0x3270)
 #define AR0234_REG_MIPI_CNTRL CCI_REG16(0x3354)
 
 /* Chip ID */
@@ -105,6 +106,10 @@ MODULE_PARM_DESC(trigger_mode,
 
 /* AR0234_REG_GRR_CONTROL1 Bits */
 #define AR0234_GRR_SLAVE_SH_SYNC BIT(8)
+
+/* AR0234_REG_LED_FLASH_CONTROL Bits */
+#define AR0234_FLASH_ENABLE BIT(8)
+#define AR0234_FLASH_LEAD BIT(7)
 
 /* Exposure control */
 #define AR0234_EXPOSURE_MIN 2
@@ -446,6 +451,8 @@ struct ar0234_hw_config {
 	unsigned int num_data_lanes;
 	enum ar0234_lane_mode_id lane_mode;
 	int trigger_mode;
+	bool flash_enable;
+	s8 flash_delay;
 };
 
 struct ar0234 {

--- a/ar0234.c
+++ b/ar0234.c
@@ -1460,11 +1460,26 @@ static int ar0234_parse_hw_config(struct ar0234 *ar0234,
 	ret = of_property_read_u32(client->dev.of_node, "trigger-mode", &tm);
 	ar0234->hw_config.trigger_mode = (ret == 0) ? tm : -1;
 
+	hw_config->flash_enable =
+		of_property_read_bool(client->dev.of_node, "flash");
+
+	if (hw_config->flash_enable) {
+		s32 delay = 0;
+
+		of_property_read_s32(client->dev.of_node, "flash-delay",
+				     &delay);
+		hw_config->flash_delay = (s8)delay;
+	}
+
 	dev_info(
 		ar0234->dev,
-		"extclk: %luHz, link_frequency: %lluHz, lanes: %d, trigger_mode: %d\n",
+		"extclk: %luHz, link_frequency: %lluHz, lanes: %d, trigger_mode: %d, flash: %s%s\n",
 		extclk_frequency, ep_cfg.link_frequencies[0],
-		hw_config->num_data_lanes, hw_config->trigger_mode);
+		hw_config->num_data_lanes, hw_config->trigger_mode,
+		hw_config->flash_enable ? "enabled" : "disabled",
+		(hw_config->flash_enable && hw_config->flash_delay) ?
+			((hw_config->flash_delay > 0) ? " (lead)" : " (lag)") :
+			"");
 
 	ret = 0;
 

--- a/ar0234.c
+++ b/ar0234.c
@@ -1477,11 +1477,15 @@ static int ar0234_parse_hw_config(struct ar0234 *ar0234,
 		of_property_read_bool(client->dev.of_node, "flash");
 
 	if (hw_config->flash_enable) {
-		s32 delay = 0;
+		u32 lead = 0, lag = 0;
 
-		of_property_read_s32(client->dev.of_node, "flash-delay",
-				     &delay);
-		hw_config->flash_delay = (s8)delay;
+		of_property_read_u32(client->dev.of_node, "flash-lead", &lead);
+		of_property_read_u32(client->dev.of_node, "flash-lag", &lag);
+
+		if (lead)
+			hw_config->flash_delay = -(s8)lead;
+		else if (lag)
+			hw_config->flash_delay = (s8)lag;
 	}
 
 	dev_info(


### PR DESCRIPTION
## Summary

- Add FLASH output pin support, configurable via Device Tree overrides (`flash`, `flash-lead`, `flash-lag`)
- Flash pin goes HIGH during exposure for synchronizing external illumination (strobes, LEDs)
- Programmable lead/lag delay via separate `flash-lead` and `flash-lag` properties, each accepting unsigned integer values (0-127)
- Document flash feature in README with practical timing units, constraints, and examples

## Test plan

- [x] Enable flash without delay: `dtoverlay=ar0234,flash` — verify FLASH pin goes HIGH during exposure
- [x] Enable flash with lead: `dtoverlay=ar0234,flash,flash-lead=10` — verify FLASH rises before exposure start
- [x] Enable flash with lag: `dtoverlay=ar0234,flash,flash-lag=10` — verify FLASH rises after exposure starts
- [x] Verify `dmesg` reports flash status and lead/lag direction correctly
- [x] Flash disabled by default: no `flash` option — verify FLASH pin stays LOW
- [x] Test flash with trigger mode enabled — verify flash is not suppressed with adequate trigger pulse width
- [x] Test on 2-lane and 4-lane configurations