### PR TITLE
Implement test pattern support

### DIFF
--- a/ar0234.c
+++ b/ar0234.c
@@ -129,19 +129,14 @@ MODULE_PARM_DESC(trigger_mode,
 #define AR0234_DGTL_GAIN_STEP 1
 
 /* Test Patterns */
-#define AR0234_TESTP_COLOUR_MIN 0
-#define AR0234_TESTP_COLOUR_MAX 0x03FF
-#define AR0234_TESTP_COLOUR_STEP 1
-#define AR0234_TESTP_RED_DEFAULT AR0234_TESTP_COLOUR_MAX
-#define AR0234_TESTP_GREENR_DEFAULT 0
-#define AR0234_TESTP_BLUE_DEFAULT 0
-#define AR0234_TESTP_GREENB_DEFAULT 0
+#define AR0234_TEST_PATTERN_COLOR_MIN 0
+#define AR0234_TEST_PATTERN_COLOR_MAX 0x03FF
+#define AR0234_TEST_PATTERN_COLOR_STEP 1
 
 #define AR0234_TEST_PATTERN_DISABLED 0
 #define AR0234_TEST_PATTERN_SOLID_COLOR 1
-#define AR0234_TEST_PATTERN_VERTICAL_COLOR_BARS 2
-#define AR0234_TEST_PATTERN_FADE_TO_GREY 3
-#define AR0234_TEST_PATTERN_PN9 4
+#define AR0234_TEST_PATTERN_COLOR_BARS 2
+#define AR0234_TEST_PATTERN_GREY_BARS 3
 #define AR0234_TEST_PATTERN_WALKING_1S 256
 
 /* Trigger modes */
@@ -330,23 +325,23 @@ static const struct cci_reg_sequence ar0234_960x600_config[] = {
 	{ AR0234_REG_READ_MODE, 0x3000 },
 };
 
+// clang-format off
 static const char *const ar0234_test_pattern_menu[] = {
 	"Disabled",
 	"Solid Color",
 	"Vertical Color Bars",
-	"Fade to Grey Vertical Color Bars",
-	"PN9",
+	"Grey Color Bars",
 	"Walking 1s",
 };
 
 static const unsigned int ar0234_test_pattern_val[] = {
 	AR0234_TEST_PATTERN_DISABLED,
 	AR0234_TEST_PATTERN_SOLID_COLOR,
-	AR0234_TEST_PATTERN_VERTICAL_COLOR_BARS,
-	AR0234_TEST_PATTERN_FADE_TO_GREY,
-	AR0234_TEST_PATTERN_PN9,
+	AR0234_TEST_PATTERN_COLOR_BARS,
+	AR0234_TEST_PATTERN_GREY_BARS,
 	AR0234_TEST_PATTERN_WALKING_1S,
 };
+// clang-format on
 
 /* regulator supplies */
 static const char *const ar0234_supply_names[] = {
@@ -1330,10 +1325,10 @@ static int ar0234_init_controls(struct ar0234 *ar0234)
 		*/
 		v4l2_ctrl_new_std(ctrl_hdlr, &ar0234_ctrl_ops,
 				  V4L2_CID_TEST_PATTERN_RED + i,
-				  AR0234_TESTP_COLOUR_MIN,
-				  AR0234_TESTP_COLOUR_MAX,
-				  AR0234_TESTP_COLOUR_STEP,
-				  AR0234_TESTP_COLOUR_MAX);
+				  AR0234_TEST_PATTERN_COLOR_MIN,
+				  AR0234_TEST_PATTERN_COLOR_MAX,
+				  AR0234_TEST_PATTERN_COLOR_STEP,
+				  AR0234_TEST_PATTERN_COLOR_MAX);
 		/* The "Solid color" pattern is white by default */
 	}
 

--- a/ar0234.c
+++ b/ar0234.c
@@ -647,9 +647,24 @@ static int ar0234_set_ctrl(struct v4l2_ctrl *ctrl)
 				ctrl->val, NULL);
 		break;
 	case V4L2_CID_TEST_PATTERN:
-		ret = 0; //ar0234_write_reg(ar0234, AR0234_REG_TEST_PATTERN_MODE,
-			//	       AR0234_REG_VALUE_16BIT,
-			//	       ar0234_test_pattern_val[ctrl->val]);
+		ret = cci_write(ar0234->regmap, AR0234_REG_TEST_PATTERN_MODE,
+				ar0234_test_pattern_val[ctrl->val], NULL);
+		break;
+	case V4L2_CID_TEST_PATTERN_RED:
+		ret = cci_write(ar0234->regmap, AR0234_REG_TEST_DATA_RED,
+				ctrl->val, NULL);
+		break;
+	case V4L2_CID_TEST_PATTERN_GREENR:
+		ret = cci_write(ar0234->regmap, AR0234_REG_TEST_DATA_GREENR,
+				ctrl->val, NULL);
+		break;
+	case V4L2_CID_TEST_PATTERN_BLUE:
+		ret = cci_write(ar0234->regmap, AR0234_REG_TEST_DATA_BLUE,
+				ctrl->val, NULL);
+		break;
+	case V4L2_CID_TEST_PATTERN_GREENB:
+		ret = cci_write(ar0234->regmap, AR0234_REG_TEST_DATA_GREENB,
+				ctrl->val, NULL);
 		break;
 	case V4L2_CID_HFLIP:
 	case V4L2_CID_VFLIP:
@@ -662,21 +677,6 @@ static int ar0234_set_ctrl(struct v4l2_ctrl *ctrl)
 				ar0234->mode.format->height + ctrl->val -
 					AR0234_FLL_OVERHEAD,
 				NULL);
-		break;
-	case V4L2_CID_TEST_PATTERN_RED:
-		ret = 0; //ar0234_write_reg(ar0234, AR0234_REG_TEST_DATA_RED,CCI_REG16(0x3072)	       AR0234_REG_VALUE_16BIT, ctrl->val);
-		break;
-	case V4L2_CID_TEST_PATTERN_GREENR:
-		ret = 0; //ar0234_write_reg(ar0234, AR0234_REG_TESTP_GREENR,
-			//	       AR0234_REG_VALUE_16BIT, ctrl->val);
-		break;
-	case V4L2_CID_TEST_PATTERN_BLUE:
-		ret = 0; //ar0234_write_reg(ar0234, AR0234_REG_TESTP_BLUE,
-		//		       AR0234_REG_VALUE_16BIT, ctrl->val);
-		break;
-	case V4L2_CID_TEST_PATTERN_GREENB:
-		ret = 0; //ar0234_write_reg(ar0234, AR0234_REG_TESTP_GREENB,
-			//	       AR0234_REG_VALUE_16BIT, ctrl->val);
 		break;
 	case V4L2_CID_HBLANK:
 		ret = -EINVAL;

--- a/ar0234.c
+++ b/ar0234.c
@@ -136,7 +136,7 @@ MODULE_PARM_DESC(trigger_mode,
 #define AR0234_TEST_PATTERN_DISABLED 0
 #define AR0234_TEST_PATTERN_SOLID_COLOR 1
 #define AR0234_TEST_PATTERN_COLOR_BARS 2
-#define AR0234_TEST_PATTERN_GREY_BARS 3
+#define AR0234_TEST_PATTERN_FADE_TO_GREY 3
 #define AR0234_TEST_PATTERN_WALKING_1S 256
 
 /* Trigger modes */
@@ -330,7 +330,7 @@ static const char *const ar0234_test_pattern_menu[] = {
 	"Disabled",
 	"Solid Color",
 	"Vertical Color Bars",
-	"Grey Color Bars",
+	"Fade to Grey Color Bars",
 	"Walking 1s",
 };
 
@@ -338,7 +338,7 @@ static const unsigned int ar0234_test_pattern_val[] = {
 	AR0234_TEST_PATTERN_DISABLED,
 	AR0234_TEST_PATTERN_SOLID_COLOR,
 	AR0234_TEST_PATTERN_COLOR_BARS,
-	AR0234_TEST_PATTERN_GREY_BARS,
+	AR0234_TEST_PATTERN_FADE_TO_GREY,
 	AR0234_TEST_PATTERN_WALKING_1S,
 };
 // clang-format on


### PR DESCRIPTION
Wire up V4L2 test pattern controls to sensor registers. Previously
the controls were registered but all register writes were stubbed out.

- Test pattern mode (R0x3070): solid color, color bars, grey bars, walking 1s
- Solid color channels (R0x3072-R0x3078): red, green_r, blue, green_b
- Remove unsupported PN9 mode
- Clean up test pattern naming (TESTP -> TEST_PATTERN, COLOUR -> COLOR)

Tested on hardware via v4l2-ctl, all modes verified.