### PR TITLE
Update README URLs for repo rename to ar0234-rpi-driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Kernel driver for AR0234
+# AR0234 kernel driver for Raspberry Pi
 
-[![Build](https://github.com/Kurokesu/ar0234-v4l2-driver/actions/workflows/build-rpi.yml/badge.svg)](https://github.com/Kurokesu/ar0234-v4l2-driver/actions/workflows/build-rpi.yml)
-[![Code format](https://github.com/Kurokesu/ar0234-v4l2-driver/actions/workflows/code-format.yml/badge.svg)](https://github.com/Kurokesu/ar0234-v4l2-driver/actions/workflows/code-format.yml)
+[![Build](https://github.com/Kurokesu/ar0234-rpi-driver/actions/workflows/build-rpi.yml/badge.svg)](https://github.com/Kurokesu/ar0234-rpi-driver/actions/workflows/build-rpi.yml)
+[![Code format](https://github.com/Kurokesu/ar0234-rpi-driver/actions/workflows/code-format.yml/badge.svg)](https://github.com/Kurokesu/ar0234-rpi-driver/actions/workflows/code-format.yml)
 [![Raspberry Pi OS Bookworm](https://img.shields.io/badge/Raspberry_Pi_OS-Bookworm-blue?logo=raspberrypi)](https://www.debian.org/releases/bookworm/)
 [![Raspberry Pi OS Trixie](https://img.shields.io/badge/Raspberry_Pi_OS-Trixie-blue?logo=raspberrypi)](https://www.debian.org/releases/trixie/)
 [![Kernel 6.12+](https://img.shields.io/badge/kernel-6.12%2B-blue?logo=raspberrypi)](https://github.com/raspberrypi/linux/tree/rpi-6.12.y)
@@ -28,8 +28,8 @@ Clone this repository:
 
 ```bash
 cd ~
-git clone https://github.com/Kurokesu/ar0234-v4l2-driver.git
-cd ar0234-v4l2-driver/
+git clone https://github.com/Kurokesu/ar0234-rpi-driver.git
+cd ar0234-rpi-driver/
 ```
 
 Run setup script:


### PR DESCRIPTION
Renaming repo to `ar0234-rpi-driver` to keep naming consistent with the rest of Kurokesu organization's Raspberry Pi driver repos.

This PR updates `README.md` references that embed the old repo name: heading, CI badge URLs, and `git clone` / `cd` lines in the setup instructions. Merge after the GitHub rename so the new URLs resolve.

## For existing local clones

Existing clones keep working via GitHub's redirect, but to align with the new name:

```bash
cd ~
mv ar0234-v4l2-driver ar0234-rpi-driver
cd ar0234-rpi-driver
git remote set-url origin https://github.com/Kurokesu/ar0234-rpi-driver.git
git fetch -v # verify
```