### PR TITLE
Rename DKMS package to ar0234-rpi-dkms

### DIFF
--- a/.github/workflows/build-rpi.yml
+++ b/.github/workflows/build-rpi.yml
@@ -18,6 +18,7 @@ on:
       - '*.dts'
       - 'Makefile'
       - '.github/workflows/build-rpi.yml'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build-rpi.yml
+++ b/.github/workflows/build-rpi.yml
@@ -10,6 +10,9 @@ on:
       - '*.c'
       - '*.dts'
       - 'Makefile'
+      - 'dkms.conf'
+      - 'dkms.postinst'
+      - 'setup.sh'
       - '.github/workflows/build-rpi.yml'
   pull_request:
     branches: [main]
@@ -17,6 +20,9 @@ on:
       - '*.c'
       - '*.dts'
       - 'Makefile'
+      - 'dkms.conf'
+      - 'dkms.postinst'
+      - 'setup.sh'
       - '.github/workflows/build-rpi.yml'
   workflow_dispatch:
 

--- a/.github/workflows/build-rpi.yml
+++ b/.github/workflows/build-rpi.yml
@@ -6,24 +6,8 @@ permissions:
 on:
   push:
     branches: [main]
-    paths:
-      - '*.c'
-      - '*.dts'
-      - 'Makefile'
-      - 'dkms.conf'
-      - 'dkms.postinst'
-      - 'setup.sh'
-      - '.github/workflows/build-rpi.yml'
   pull_request:
     branches: [main]
-    paths:
-      - '*.c'
-      - '*.dts'
-      - 'Makefile'
-      - 'dkms.conf'
-      - 'dkms.postinst'
-      - 'setup.sh'
-      - '.github/workflows/build-rpi.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -6,15 +6,9 @@ permissions:
 on:
   push:
     branches: [main]
-    paths:
-      - '*.c'
-      - '.clang-format'
-      - '.github/workflows/code-format.yml'
   pull_request:
-    paths:
-      - '*.c'
-      - '.clang-format'
-      - '.github/workflows/code-format.yml'
+    branches: [main]
+  workflow_dispatch:
 
 jobs:
   clang-format:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: GPL-2.0
+# SPDX-License-Identifier: GPL-2.0-only
 # Copyright (c) 2026, UAB Kurokesu. All rights reserved.
 #
 # Makefile for camera driver on Raspberry Pi (device tree overlay + kernel module)
@@ -7,7 +7,7 @@ SRC_DIR   := $(shell pwd)
 BUILD_DIR := build
 
 DRV_SRC   := $(wildcard *.c)
-DRV_NAME  := $(basename $(DRV_SRC))
+DRV_NAME  := $(shell grep '^BUILT_MODULE_NAME=' dkms.conf | cut -d'"' -f2)
 DTS       := $(wildcard *-overlay.dts)
 DTBO      := $(DRV_NAME).dtbo
 DTC       := dtc
@@ -16,8 +16,15 @@ DTC_FLAGS := -Wno-interrupts_property -Wno-unit_address_vs_reg -@ -I dts -O dtb
 KDIR      ?= /lib/modules/$(shell uname -r)/build
 CCFLAGS   := -Werror
 
+# Status line formatter (8-char tag column, arg at col 11)
+PRINT = printf '  %-7s %s\n'
+
 ifeq ($(DRV_SRC),)
   $(error No .c source file found in project root)
+endif
+
+ifeq ($(DRV_NAME),)
+  $(error No BUILT_MODULE_NAME found in dkms.conf)
 endif
 
 ifeq ($(DTS),)
@@ -35,7 +42,9 @@ dtbo: $(BUILD_DIR)/$(DTBO)
 module: $(BUILD_DIR)/$(DRV_NAME).ko
 
 $(BUILD_DIR)/$(DTBO): $(DTS) | $(BUILD_DIR)
-	$(DTC) $(DTC_FLAGS) -o $@ $<
+	@$(PRINT) DTC $@
+	@$(DTC) $(DTC_FLAGS) -o $@ $<
+	@$(PRINT) BUILT $@
 
 $(BUILD_DIR)/Kbuild: | $(BUILD_DIR)
 	@echo "ccflags-y += $(CCFLAGS)" > $@
@@ -43,13 +52,18 @@ $(BUILD_DIR)/Kbuild: | $(BUILD_DIR)
 	@ln -sf $(SRC_DIR)/$(DRV_SRC) $(BUILD_DIR)/$(DRV_SRC)
 
 $(BUILD_DIR)/$(DRV_NAME).o: $(DRV_SRC) $(BUILD_DIR)/Kbuild
-	$(MAKE) -C $(KDIR) M=$(SRC_DIR)/$(BUILD_DIR) $(DRV_NAME).o
+	@$(PRINT) KBUILD $(DRV_NAME).o
+	@$(MAKE) -C $(KDIR) M=$(SRC_DIR)/$(BUILD_DIR) $(DRV_NAME).o
+	@$(PRINT) BUILT $@
 
 $(BUILD_DIR)/$(DRV_NAME).ko: $(DRV_SRC) $(BUILD_DIR)/Kbuild
-	$(MAKE) -C $(KDIR) M=$(SRC_DIR)/$(BUILD_DIR) modules
+	@$(PRINT) KBUILD $(DRV_NAME).ko
+	@$(MAKE) -C $(KDIR) M=$(SRC_DIR)/$(BUILD_DIR) modules
+	@$(PRINT) BUILT $@
 
 $(BUILD_DIR):
 	@mkdir -p $(BUILD_DIR)
 
 clean:
-	rm -rf $(BUILD_DIR)
+	@$(PRINT) CLEAN $(BUILD_DIR)
+	@rm -rf $(BUILD_DIR)

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,9 +1,16 @@
-MAKE="make module KDIR=/lib/modules/${kernelver}/build"
-CLEAN="make clean"
-BUILT_MODULE_NAME=ar0234
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (c) 2026, UAB Kurokesu. All rights reserved.
+
+PACKAGE_NAME="ar0234-rpi-dkms"
+PACKAGE_VERSION="0.0.1"
+
+BUILT_MODULE_NAME="ar0234"
 BUILT_MODULE_LOCATION="build"
 DEST_MODULE_LOCATION="/updates"
-PACKAGE_NAME=ar0234-dkms
-PACKAGE_VERSION=0.0.1
-AUTOINSTALL="yes"
+
+MAKE="make module KDIR=/lib/modules/${kernelver}/build"
+CLEAN="make clean"
+
 POST_INSTALL="dkms.postinst"
+
+AUTOINSTALL="yes"

--- a/dkms.postinst
+++ b/dkms.postinst
@@ -1,5 +1,16 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (c) 2026, UAB Kurokesu. All rights reserved.
+#
+# DKMS post-install: build and install the device tree overlay to /boot.
+
+set -e
+
+# Status line formatter (matches Makefile's PRINT)
+print() { printf '  %-7s %s\n' "$1" "$2"; }
 
 cd "$(dirname "$0")"
 make dtbo
+
+print INSTALL "/boot/overlays/$(basename build/*.dtbo)"
 install -m 644 build/*.dtbo /boot/overlays/

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-# SPDX-License-Identifier: GPL-2.0
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
 # Copyright (c) 2026, UAB Kurokesu. All rights reserved.
 #
 # Install camera driver (device tree overlay + kernel module via DKMS)
@@ -8,44 +8,65 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-PACKAGE_NAME=$(grep '^PACKAGE_NAME=' "$SCRIPT_DIR/dkms.conf" | cut -d'=' -f2)
-VERSION=$(grep '^PACKAGE_VERSION=' "$SCRIPT_DIR/dkms.conf" | cut -d'=' -f2)
+# Status line formatter (matches Makefile's PRINT)
+print() { printf '  %-7s %s\n' "$1" "$2"; }
+
+PACKAGE_NAME=$(grep '^PACKAGE_NAME=' "$SCRIPT_DIR/dkms.conf" | cut -d'"' -f2)
+VERSION=$(grep '^PACKAGE_VERSION=' "$SCRIPT_DIR/dkms.conf" | cut -d'"' -f2)
+
+echo "Kurokesu Camera Driver Installer"
 
 if [ -z "$PACKAGE_NAME" ] || [ -z "$VERSION" ]; then
-    echo "Error: Failed to read PACKAGE_NAME or PACKAGE_VERSION from dkms.conf"
-    exit 1
+	echo "" >&2
+	echo "Error: Failed to read PACKAGE_NAME or PACKAGE_VERSION from dkms.conf" >&2
+	exit 1
 fi
+
+echo "${PACKAGE_NAME} v${VERSION}"
+echo ""
 
 DKMS_SRC="/usr/src/${PACKAGE_NAME}-${VERSION}"
 
-if ! command -v dkms &>/dev/null; then
-    echo "Error: dkms is not installed. Install it with: sudo apt install -y --no-install-recommends dkms"
-    exit 1
+if ! command -v dkms >/dev/null 2>&1; then
+	echo "Error: dkms is not installed. Install with:" >&2
+	echo "    sudo apt install -y --no-install-recommends dkms" >&2
+	exit 1
 fi
 
-OLD_VER=$(dkms status -m "$PACKAGE_NAME" 2>/dev/null | cut -d'/' -f2 | cut -d',' -f1)
-if [ -n "$OLD_VER" ]; then
-    echo "Removing previous DKMS registration: ${PACKAGE_NAME}/${OLD_VER}"
-    sudo dkms remove "${PACKAGE_NAME}/${OLD_VER}" --all || true
+SENSOR=${PACKAGE_NAME%-rpi-dkms}
+NAMES="$PACKAGE_NAME"
+if [ "$SENSOR" != "$PACKAGE_NAME" ]; then
+	NAMES="$NAMES ${SENSOR}-dkms ${SENSOR}"
 fi
 
-echo "Copying driver source to ${DKMS_SRC}"
-sudo rm -rf "$DKMS_SRC"
-sudo mkdir -p "$DKMS_SRC"
-sudo cp "$SCRIPT_DIR/dkms.conf" "$DKMS_SRC/"
-sudo cp "$SCRIPT_DIR/dkms.postinst" "$DKMS_SRC/"
-sudo cp "$SCRIPT_DIR/Makefile" "$DKMS_SRC/"
-sudo cp "$SCRIPT_DIR"/*.c "$DKMS_SRC/"
-sudo cp "$SCRIPT_DIR"/*.dts "$DKMS_SRC/"
+for name in $NAMES; do
+	ver=$(dkms status -m "$name" 2>/dev/null | awk -F'[/,: ]' '{print $2; exit}')
+	if [ -n "$ver" ]; then
+		print CLEAN "${name}/${ver}"
+		if ! out=$(dkms remove "${name}/${ver}" --all 2>&1); then
+			print WARN "could not fully remove ${name}/${ver}" >&2
+			printf '%s\n' "$out" >&2
+		fi
+	fi
+done
 
-echo "DKMS: adding ${PACKAGE_NAME}/${VERSION}"
-sudo dkms add -m "$PACKAGE_NAME" -v "$VERSION"
+print COPY "driver source -> $DKMS_SRC"
+rm -rf "$DKMS_SRC"
+mkdir -p "$DKMS_SRC"
+cp "$SCRIPT_DIR/dkms.conf" "$DKMS_SRC/"
+cp "$SCRIPT_DIR/dkms.postinst" "$DKMS_SRC/"
+cp "$SCRIPT_DIR/Makefile" "$DKMS_SRC/"
+cp "$SCRIPT_DIR"/*.c "$DKMS_SRC/"
+cp "$SCRIPT_DIR"/*.dts "$DKMS_SRC/"
 
-echo "DKMS: building ${PACKAGE_NAME}/${VERSION}"
-sudo dkms build -m "$PACKAGE_NAME" -v "$VERSION"
+print DKMS "add ${PACKAGE_NAME}/${VERSION}"
+dkms add -m "$PACKAGE_NAME" -v "$VERSION"
 
-echo "DKMS: installing ${PACKAGE_NAME}/${VERSION}"
-sudo dkms install -m "$PACKAGE_NAME" -v "$VERSION"
+print DKMS "build ${PACKAGE_NAME}/${VERSION}"
+dkms build -m "$PACKAGE_NAME" -v "$VERSION"
+
+print DKMS "install ${PACKAGE_NAME}/${VERSION}"
+dkms install -m "$PACKAGE_NAME" -v "$VERSION"
 
 echo ""
 echo "Done."


### PR DESCRIPTION
## Summary

- Rename DKMS package from `ar0234-dkms` to `ar0234-rpi-dkms` to match the sibling driver naming convention. Migration is handled transparently by the modernized `setup.sh`.
- Sync the build system with the source of truth in `imx585-rpi-driver`: modernized Makefile (`PRINT` helper, `DRV_NAME` derived from `dkms.conf`), quoted `dkms.conf` with SPDX header, hardened `dkms.postinst` (`set -e`, matching `print` helper) and the sensor-agnostic `setup.sh` with the bare-name migration cleanup.
- Simplify CI triggers on both `build-rpi.yml` and `code-style.yml`: add `workflow_dispatch` to both and drop paths filters entirely. Required status checks and paths filters don't compose — a PR whose files fall outside the filter never posts the required check and stalls on `Expected — Waiting for status to be reported`. Also drops the stale `code-format.yml` self-reference in `code-style.yml`'s old paths list, left over from a prior rename.

## Test plan

- [x] Real migration on Pi: pre-state `ar0234-dkms/0.0.1` installed. Running `setup.sh` produces one `CLEAN` line for the legacy entry then a clean add/build/install cycle for `ar0234-rpi-dkms/0.0.1`. No `WARN`. Module and overlay refreshed with new mtimes.
- [x] Reinstall idempotency: one `CLEAN` line for the current entry, clean install cycle, no `WARN`.
- [x] Post-install DKMS state: only `ar0234-rpi-dkms` registered, no fossils in `/var/lib/dkms`.
- [x] Bare-name and `-dkms` legacy variant cleanup covered by the same derivation logic already validated on `imx585-rpi-driver` and `ar0822-rpi-driver`.