### PR TITLE
dkms: Bump PACKAGE_VERSION to 0.1.0

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -2,7 +2,7 @@
 # Copyright (c) 2026, UAB Kurokesu. All rights reserved.
 
 PACKAGE_NAME="ar0234-rpi-dkms"
-PACKAGE_VERSION="0.0.1"
+PACKAGE_VERSION="0.1.0"
 
 BUILT_MODULE_NAME="ar0234"
 BUILT_MODULE_LOCATION="build"


### PR DESCRIPTION
## Summary

- Bump the version for the first packaged release, matching the 0.1.0-1
  changelog entry on the new debian/latest branch
- dkms.conf on main is the version of record, the packaging build guard
  asserts it maps to the changelog upstream version and fails otherwise

## Test plan

- [x] Local package build replay against this version passes the
  debian/rules guard and produces a correct .deb